### PR TITLE
Added shell scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,27 @@ Makes [WebJars](http://webjars.org) super-easy to find and install from the comm
 
 Requires Java 5 and Maven 3.0.4.
 
-## Invocation
+## Installation
 
-To inovke the plugin by simply typing `mvn webjars:<goal>`, you must either add the plugin to your project, or add it to settings.xml.
+### Native
+
+Download the [latest release](https://github.com/webjars/webjars-maven-plugin/releases). Unpack it somewhere and add the bin folder to your path. You can now run `webjars list jquery`.
+
+### Maven
+
+To invoke the plugin with the `mvn webjars:<goal>` shortcut, you must either add the plugin to Maven's settings.xml or to your project's pom.xml. If you do neither, you must use `mvn org.webjars:webjars-maven-plugin:<goal>`.
+
+#### Global
+
+In settings.xml (in $USER_HOME/.m2 by default), add the following line to the `pluginGroups` element ([more info](http://maven.apache.org/settings.html#Plugin_Groups)):
+
+````xml
+<pluginGroup>org.webjars</pluginGroup>
+````
+
+The shortcut is now available globally.
+
+#### Project-specific
 
 In your project's POM, add the plugin to the `plugins` element:
 
@@ -20,13 +38,7 @@ In your project's POM, add the plugin to the `plugins` element:
 </plugin>
 ````
 
-In settings.xml, add the following line to the `pluginGroups` element ([more info](http://maven.apache.org/settings.html#Plugin_Groups)):
-
-````xml
-<pluginGroup>org.webjars</pluginGroup>
-````
-
-If you do neither, you must use `mvn org.webjars:webjars-maven-plugin:<goal>`.
+The shortcut is now available in the project's directory
 
 ## Goals
 
@@ -36,9 +48,9 @@ Lists all available WebJars. Can be used from any directory.
 
 The optional `webjar` parameter filters the results.
 
-`mvn webjars:list`
+`webjars list` or `mvn webjars:list`
 
-`mvn webjars:list -Dwebjar=jquery`
+`webjars list jquery` or `mvn webjars:list -Dwebjar=jquery`
 
 ### install
 
@@ -46,9 +58,9 @@ Adds a webjar to your dependencies.
 
 The required `webjar` parameter specifies which WebJar to install. The format is: `<name>[:<version]`. If there is no version, the latest version is used.
 
-`mvn webjars:install -Dwebjar=jquery`
+`webjars install jquery` or `mvn webjars:install -Dwebjar=jquery`
 
-`mvn webjars:install -Dwebjar=jquery:1.10.1`
+`webjars install jquery:1.10.1` or `mvn webjars:install -Dwebjar=jquery:1.10.1`
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
       <artifactId>sisu-guava</artifactId>
       <version>0.11.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+      <version>1.1</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -107,6 +112,45 @@
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>appassembler-maven-plugin</artifactId>
+        <version>1.4</version>
+        <executions>
+          <execution>
+            <id>make-script</id>
+            <phase>package</phase>
+            <goals>
+              <goal>assemble</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <programs>
+            <program>
+              <mainClass>org.webjars.WebJarsCommandLine</mainClass>
+              <name>webjars</name>
+            </program>
+          </programs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptors>
+            <descriptor>src/main/assembly/assembly.xml</descriptor>
+          </descriptors>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -1,0 +1,18 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>dist</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/appassembler/repo</directory>
+      <outputDirectory>repo</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/appassembler/bin</directory>
+      <outputDirectory>bin</outputDirectory>
+      <fileMode>0555</fileMode>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/src/main/java/org/webjars/ListMojo.java
+++ b/src/main/java/org/webjars/ListMojo.java
@@ -1,10 +1,6 @@
 package org.webjars;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
-
-import java.util.Map;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.plugin.AbstractMojo;
@@ -26,30 +22,11 @@ public class ListMojo extends AbstractMojo {
   private String webjar;
 
   public void execute() throws MojoExecutionException, MojoFailureException {
-    Multimap<String, ArtifactVersion> artifacts = MavenCentral.getArtifacts(null, null, getLog());
-
-    artifacts = Multimaps.filterEntries(artifacts, new Predicate<Map.Entry<String, ArtifactVersion>>() {
-      public boolean apply(Map.Entry<String, ArtifactVersion> entry) {
-        return webjar == null || entry.getKey().contains(webjar);
-      }
-    });
+    WebJars webJars = new WebJars(getLog());
+    Multimap<String, ArtifactVersion> artifacts = webJars.list(webjar);
 
     if (artifacts.isEmpty()) {
-      MavenCentral.reportNoWebJarsFound(webjar, null, getLog());
-      return;
+      throw new MojoFailureException("No results.");
     }
-
-    StringBuilder sb = new StringBuilder("Found the following artifacts in Maven Central:\n");
-    for (String artifact : artifacts.keySet()) {
-      if (webjar == null || artifact.contains(webjar)) {
-        sb.append(artifact).append(" [");
-        for (ArtifactVersion version : artifacts.get(artifact)) {
-          sb.append(" ").append(version).append(" ");
-        }
-        sb.append("]\n");
-      }
-    }
-
-    getLog().info(sb);
   }
 }

--- a/src/main/java/org/webjars/MavenCentral.java
+++ b/src/main/java/org/webjars/MavenCentral.java
@@ -13,12 +13,11 @@ import java.util.Comparator;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
 public class MavenCentral {
 
-  public static Multimap<String, ArtifactVersion> getArtifacts(String artifact, ArtifactVersion version, Log log) throws MojoFailureException {
+  public static Multimap<String, ArtifactVersion> getArtifacts(String artifact, ArtifactVersion version, Log log) {
     String query = "g:\"org.webjars\"";
     if (artifact != null) {
       query += " AND a:\"" + artifact + "\"";
@@ -55,10 +54,8 @@ public class MavenCentral {
     return artifacts;
   }
 
-  public static void reportNoWebJarsFound(String artifact, ArtifactVersion version, Log log) throws MojoFailureException {
+  public static void reportNoWebJarsFound(String artifact, ArtifactVersion version, Log log) {
     String errorMessage = "No WebJar found matching " + artifact + (version != null ? ":" + version : "");
     log.error(errorMessage);
-
-    throw new MojoFailureException(errorMessage);
   }
 }

--- a/src/main/java/org/webjars/WebJars.java
+++ b/src/main/java/org/webjars/WebJars.java
@@ -1,0 +1,71 @@
+package org.webjars;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+
+import java.util.Map;
+
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.plugin.logging.Log;
+
+public class WebJars {
+
+  private final Log log;
+
+  public WebJars(Log log) {
+    this.log = log;
+  }
+
+  public Multimap<String, ArtifactVersion> list(final String webjar) {
+    Multimap<String, ArtifactVersion> artifacts = MavenCentral.getArtifacts(null, null, log);
+
+    artifacts = Multimaps.filterEntries(artifacts, new Predicate<Map.Entry<String, ArtifactVersion>>() {
+      public boolean apply(Map.Entry<String, ArtifactVersion> entry) {
+        return webjar == null || entry.getKey().contains(webjar);
+      }
+    });
+
+    if (artifacts.isEmpty()) {
+      MavenCentral.reportNoWebJarsFound(webjar, null, log);
+      return artifacts;
+    }
+
+    StringBuilder sb = new StringBuilder("Found the following artifacts in Maven Central:\n");
+    for (String artifact : artifacts.keySet()) {
+      if (webjar == null || artifact.contains(webjar)) {
+        sb.append(artifact).append(" [");
+        for (ArtifactVersion version : artifacts.get(artifact)) {
+          sb.append(" ").append(version).append(" ");
+        }
+        sb.append("]\n");
+      }
+    }
+
+    log.info(sb);
+
+    return artifacts;
+  }
+
+  public void install(String webJar) {
+    CommandLine commandLine = CommandLine.parse("mvn org.webjars:webjars-maven-plugin:install -Dwebjar=" + webJar);
+    try {
+      new DefaultExecutor().execute(commandLine);
+    } catch (Exception e) {
+      log.error("Could not install " + webJar, e);
+    }
+  }
+
+  public void help() {
+    log.info("Available commands:");
+    log.info("list <webJar>\n\tLists all available WebJars.");
+    log.info("\tCan be used from any directory.");
+    log.info("\tThe optional parameter filters the results.");
+    log.info("install <webJar>\n\tAdds the given WebJar to the project's dependencies or updates an existing dependency.");
+    log.info("\tMust be used from a Maven project directory.");
+    log.info("\tThe required parameter specifies which WebJar to install.");
+    log.info("\tThe format is: <name>[:<version]. If there is no version, the latest version is used.");
+  }
+}

--- a/src/main/java/org/webjars/WebJarsCommandLine.java
+++ b/src/main/java/org/webjars/WebJarsCommandLine.java
@@ -1,0 +1,27 @@
+package org.webjars;
+
+import org.apache.maven.plugin.logging.SystemStreamLog;
+
+public class WebJarsCommandLine {
+
+  public static void main(String[] args) {
+    SystemStreamLog log = new SystemStreamLog();
+    String command = args[0];
+    WebJars webJars = new WebJars(log);
+
+    if ("list".equals(command)) {
+      webJars.list(args.length > 1 ? args[1] : null);
+    } else if ("install".equals(command)) {
+      if (args.length < 2) {
+        log.error("Please specify a WebJar to be installed");
+        return;
+      }
+      webJars.install(args[1]);
+    } else if ("help".equals(command)) {
+      webJars.help();
+    } else {
+      log.error("Invalid command.");
+      webJars.help();
+    }
+  }
+}


### PR DESCRIPTION
This allows plugin to be invoked more concisely: `webjars list jquery`.

It would be great if someone could test this on Mac OS and/or Windows.
